### PR TITLE
Reduce background animation load

### DIFF
--- a/components/backgrounds/hole/hole-background.tsx
+++ b/components/backgrounds/hole/hole-background.tsx
@@ -14,8 +14,8 @@ type HoleBackgroundProps = React.ComponentProps<"div"> & {
 
 function HoleBackground({
   strokeColor = "#737373",
-  numberOfLines = 50,
-  numberOfDiscs = 50,
+  numberOfLines = 30,
+  numberOfDiscs = 30,
   particleRGBColor = [255, 255, 255],
   className,
   children,
@@ -219,7 +219,7 @@ function HoleBackground({
       (width - stateRef.current.particleArea.sw) / 2;
     stateRef.current.particleArea.ex =
       (width - stateRef.current.particleArea.ew) / 2;
-    const totalParticles = 100;
+    const totalParticles = 50;
 
     for (let i = 0; i < totalParticles; i++) {
       stateRef.current.particles.push(initParticle(true));
@@ -330,7 +330,24 @@ function HoleBackground({
 
     if (!canvas) return;
     init();
-    tick();
+
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    const start = () => {
+      cancelAnimationFrame(animationFrameIdRef.current);
+      animationFrameIdRef.current = requestAnimationFrame(tick);
+    };
+
+    const stop = () => cancelAnimationFrame(animationFrameIdRef.current);
+
+    const handleVisibilityChange = () => {
+      if (document.hidden || media.matches) {
+        stop();
+      } else {
+        start();
+      }
+    };
+
     const handleResize = () => {
       setSize();
       setDiscs();
@@ -338,11 +355,17 @@ function HoleBackground({
       setParticles();
     };
 
+    handleVisibilityChange();
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    media.addEventListener("change", handleVisibilityChange);
     window.addEventListener("resize", handleResize);
 
     return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      media.removeEventListener("change", handleVisibilityChange);
       window.removeEventListener("resize", handleResize);
-      cancelAnimationFrame(animationFrameIdRef.current);
+      stop();
     };
   }, [init, tick, setSize, setDiscs, setLines, setParticles]);
 

--- a/components/backgrounds/stars.tsx
+++ b/components/backgrounds/stars.tsx
@@ -24,7 +24,7 @@ function generateStars(count: number, starColor: string) {
 }
 
 function StarLayer({
-  count = 200,
+  count = 100,
   size = 1,
   starColor = "#fff",
   className,
@@ -95,9 +95,9 @@ function StarsBackground({
         className={cn({ "pointer-events-none": !pointerEvents })}
         style={{ transform: `translate(${offset.x}px, ${offset.y}px)` }}
       >
-        <StarLayer count={200} size={1} starColor={starColor} />
-        <StarLayer count={80} size={2} starColor={starColor} />
-        <StarLayer count={40} size={3} starColor={starColor} />
+        <StarLayer count={100} size={1} starColor={starColor} />
+        <StarLayer count={40} size={2} starColor={starColor} />
+        <StarLayer count={20} size={3} starColor={starColor} />
       </div>
       {children}
     </div>


### PR DESCRIPTION
## Summary
- lower starfield density for better performance
- lighten black hole animation and respect reduced motion/visibility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689f019c648c83239cfb45624474adf7