### PR TITLE
Add interactive skill map component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import { HeroSection } from "@/components/home/hero";
 import { SkillsOverviewSection } from "@/components/home/skills-overview";
 import { WorkSection } from "@/components/home/work";
 import { TestimonialsSection } from "@/components/home/testimonials";
+import SkillMap from "@/components/SkillMap";
 
 export default function HomePage() {
   return (
@@ -10,6 +11,23 @@ export default function HomePage() {
       <SkillsOverviewSection />
       <WorkSection />
       <TestimonialsSection />
+      <section className="py-20 bg-background" id="skill-map">
+        <div className="container mx-auto px-4 space-y-4">
+          <h2 className="text-2xl font-bold">Interconnected Skill Map</h2>
+          <p className="max-w-3xl text-slate-500">
+            Domains orbit my core problem-solving center. Each skill connects to its domain and bridges others.
+          </p>
+          <SkillMap dark />
+          <ul className="mt-4 grid gap-2 text-sm text-slate-500 md:grid-cols-2">
+            <li>
+              <b>Domains:</b> Core Problem Solving; Technical Trades; Engineering & Design; Digital & Creative; Business & Marketing
+            </li>
+            <li>
+              <b>Sample skills:</b> Learning Agility; Embedded Systems Programming; Fusion 360; SEO & Content Strategy; Web Development
+            </li>
+          </ul>
+        </div>
+      </section>
     </>
   );
 }

--- a/components/SkillMap.tsx
+++ b/components/SkillMap.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import Papa from "papaparse";
+import { useEffect, useRef, useState } from "react";
+
+// react-force-graph must be client-only
+const ForceGraph2D = dynamic(
+  () => import("react-force-graph").then(m => m.ForceGraph2D),
+  { ssr: false }
+);
+
+type Node = { id: string; label: string; type: "domain" | "skill"; fx?: number; fy?: number; degree?: number };
+type Link = { source: string; target: string };
+
+function polar(cx: number, cy: number, r: number, deg: number) {
+  const a = (deg * Math.PI) / 180;
+
+  return { x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) };
+}
+
+export default function SkillMap({
+  nodesCsv = "/skills/nodes.csv",
+  linksCsv = "/skills/links.csv",
+  dark = true
+}: { nodesCsv?: string; linksCsv?: string; dark?: boolean }) {
+  const fgRef = useRef<any>(null);
+  const [data, setData] = useState<{ nodes: Node[]; links: Link[] } | null>(null);
+
+  useEffect(() => {
+    const loadNodes = new Promise<Node[]>((resolve) =>
+      Papa.parse(nodesCsv, { download: true, header: true, skipEmptyLines: true,
+        complete: (res) => resolve((res.data as Node[]).map(n => ({ ...n, type: n.type as any }))) })
+    );
+    const loadLinks = new Promise<Link[]>((resolve) =>
+      Papa.parse(linksCsv, { download: true, header: true, skipEmptyLines: true,
+        complete: (res) => resolve(res.data as Link[]) })
+    );
+
+    Promise.all([loadNodes, loadLinks]).then(([nodes, links]) => {
+      // degree map (optional: affects label sizing if you want)
+      const deg = new Map<string, number>();
+
+      links.forEach(l => {
+        deg.set(l.source, (deg.get(l.source) || 0) + 1);
+        deg.set(l.target, (deg.get(l.target) || 0) + 1);
+      });
+      nodes.forEach(n => (n.degree = deg.get(n.id) || 0));
+
+      // deterministic layout (no force jiggle)
+      const W = 1200, H = 720, cx = W / 2, cy = H / 2;
+      const domains = nodes.filter(n => n.type === "domain");
+      const skills = nodes.filter(n => n.type === "skill");
+
+      // domains around a ring
+      const step = 360 / domains.length;
+
+      domains.forEach((d, i) => {
+        const { x, y } = polar(cx, cy, 220, i * step - 90);
+
+        d.fx = x; d.fy = y;
+      });
+
+      // map skill → home domain (first domain link found)
+      const home = new Map<string, string>();
+
+      links.forEach(l => {
+        const s = nodes.find(n => n.id === l.source);
+        const t = nodes.find(n => n.id === l.target);
+
+        if (s && t) {
+          if (s.type === "domain" && t.type === "skill") home.set(t.id, s.id);
+          if (t.type === "domain" && s.type === "skill") home.set(s.id, t.id);
+        }
+      });
+
+      // orbit skills around their home domain (two rings for spacing)
+      const grouped: Record<string, Node[]> = {};
+
+      skills.forEach(s => {
+        const key = home.get(s.id) || domains[0].id;
+
+        grouped[key] = grouped[key] || [];
+        grouped[key].push(s);
+      });
+      Object.entries(grouped).forEach(([domId, arr]) => {
+        const d = domains.find(x => x.id === domId)!;
+        const r1 = 95, r2 = 145;
+
+        arr.forEach((s, i) => {
+          const r = i % 2 === 0 ? r1 : r2;
+          const angle = (360 / arr.length) * i;
+          const { x, y } = polar(d.fx!, d.fy!, r, angle);
+
+          s.fx = x; s.fy = y;
+        });
+      });
+
+      setData({ nodes, links });
+    });
+  }, [nodesCsv, linksCsv]);
+
+  const colors = {
+    bg: dark ? "#0B1020" : "#FFFFFF",
+    text: dark ? "#E5E7EB" : "#111827",
+    domain: "#4F46E5", // indigo-600
+    skill: "#10B981",  // emerald-500
+    link: dark ? "#334155" : "#CBD5E1"
+  };
+
+  const nodeCanvasObject = (node: any, ctx: CanvasRenderingContext2D) => {
+    const r = node.type === "domain" ? 12 : 8;
+
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, r, 0, 2 * Math.PI);
+    ctx.fillStyle = node.type === "domain" ? colors.domain : colors.skill;
+    ctx.fill();
+
+    const label = node.label || node.id;
+    const size = Math.max(10, node.type === "domain" ? 14 : 11);
+
+    ctx.font = `${size}px Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto`;
+    ctx.fillStyle = colors.text;
+    ctx.textBaseline = "middle";
+    ctx.textAlign = "left";
+    ctx.fillText(label, node.x + r + 6, node.y);
+  };
+
+  if (!data) {
+    return <div className="h-[560px] w-full rounded-2xl border border-slate-700" style={{ background: colors.bg }} />;
+  }
+
+  return (
+    <div className="relative w-full h-[560px] rounded-2xl border border-slate-700" style={{ background: colors.bg }}>
+      <ForceGraph2D
+        ref={fgRef}
+        enablePanInteraction
+        enableZoomInteraction
+        backgroundColor={colors.bg}
+        cooldownTime={0}         // fixed positions; no force animation
+        graphData={data}
+        linkColor={() => colors.link}
+        nodeCanvasObject={nodeCanvasObject}
+        nodeRelSize={1}
+      />
+      {/* Legend */}
+      <div
+        className="absolute right-3 top-3 rounded-md px-3 py-2 text-sm shadow"
+        style={{ background: dark ? "rgba(31,41,55,0.9)" : "rgba(255,255,255,0.95)", color: colors.text }}
+      >
+        <div className="flex items-center gap-2">
+          <span className="inline-block h-3 w-3 rounded-full" style={{ background: colors.domain }} /> Domains
+        </div>
+        <div className="mt-1 flex items-center gap-2">
+          <span className="inline-block h-3 w-3 rounded-full" style={{ background: colors.skill }} /> Skills
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-  "dev": "next dev --turbopack -H 0.0.0.0 -p 3000",
-  "build": "next build",
-  "start": "next start -H 0.0.0.0 -p 3000",
-  "lint": "eslint --fix"
-},
+    "dev": "next dev --turbopack -H 0.0.0.0 -p 3000",
+    "build": "next build",
+    "start": "next start -H 0.0.0.0 -p 3000",
+    "lint": "eslint --fix"
+  },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",
     "@heroui/react": "2.7.8",
@@ -25,8 +25,10 @@
     "intl-messageformat": "10.7.16",
     "next": "15.3.1",
     "next-themes": "0.4.6",
+    "papaparse": "^5.5.3",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "react-force-graph": "^1.48.0"
   },
   "devDependencies": {
     "@eslint/compat": "1.2.8",

--- a/public/skills/links.csv
+++ b/public/skills/links.csv
@@ -1,0 +1,28 @@
+source,target
+Core Problem Solving,Learning Agility
+Core Problem Solving,Pattern Recognition
+Core Problem Solving,Adaptability
+Core Problem Solving,Knowledge Breadth
+
+Technical Trades,Masonry & Construction
+Technical Trades,Woodworking & Woodturning
+Technical Trades,Electrical Engineering Fundamentals
+
+Engineering & Design,CAD/CAM (Fusion 360, Aspire)
+Engineering & Design,PCB Design (Eagle, KiCad)
+Engineering & Design,Embedded Systems Programming
+
+Digital & Creative,Web Development (HTML/CSS/JS/Next.js)
+Digital & Creative,Adobe/DaVinci (Video & Design)
+
+Business & Marketing,SEO & Content Strategy
+Business & Marketing,Brand Building & GTM
+
+# cross-domain bridges
+Technical Trades,Engineering & Design
+Engineering & Design,Digital & Creative
+Digital & Creative,Business & Marketing
+Core Problem Solving,Technical Trades
+Core Problem Solving,Engineering & Design
+Core Problem Solving,Digital & Creative
+Core Problem Solving,Business & Marketing

--- a/public/skills/nodes.csv
+++ b/public/skills/nodes.csv
@@ -1,0 +1,21 @@
+id,label,type
+Core Problem Solving,Core Problem Solving,domain
+Technical Trades,Technical Trades,domain
+Engineering & Design,Engineering & Design,domain
+Digital & Creative,Digital & Creative,domain
+Business & Marketing,Business & Marketing,domain
+
+Learning Agility,Learning Agility,skill
+Pattern Recognition,Pattern Recognition,skill
+Adaptability,Adaptability,skill
+Knowledge Breadth,Knowledge Breadth,skill
+Masonry & Construction,Masonry & Construction,skill
+Woodworking & Woodturning,Woodworking & Woodturning,skill
+Electrical Engineering Fundamentals,Electrical Engineering Fundamentals,skill
+CAD/CAM (Fusion 360, Aspire),CAD/CAM (Fusion 360, Aspire),skill
+PCB Design (Eagle, KiCad),PCB Design (Eagle, KiCad),skill
+Embedded Systems Programming,Embedded Systems Programming,skill
+Web Development (HTML/CSS/JS/Next.js),Web Development (HTML/CSS/JS/Next.js),skill
+Adobe/DaVinci (Video & Design),Adobe/DaVinci (Video & Design),skill
+SEO & Content Strategy,SEO & Content Strategy,skill
+Brand Building & GTM,Brand Building & GTM,skill


### PR DESCRIPTION
## Summary
- install react-force-graph and papaparse
- create CSV-driven SkillMap component with deterministic layout
- render skill map after testimonials on home page with CSV data

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f0cd8be7083238a7e4107a41f1957