### PR TITLE
Use react-force-graph-2d directly

### DIFF
--- a/components/SkillMap.tsx
+++ b/components/SkillMap.tsx
@@ -6,7 +6,7 @@ import { useEffect, useRef, useState } from "react";
 
 // react-force-graph must be client-only
 const ForceGraph2D = dynamic(
-  () => import("react-force-graph").then(m => m.ForceGraph2D),
+  () => import("react-force-graph-2d"),
   { ssr: false }
 );
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "papaparse": "^5.5.3",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-force-graph": "^1.48.0"
+    "react-force-graph": "^1.48.0",
+    "react-force-graph-2d": "^1.28.0"
   },
   "devDependencies": {
     "@eslint/compat": "1.2.8",


### PR DESCRIPTION
## Summary
- fix SkillMap force graph import by using `react-force-graph-2d`
- add `react-force-graph-2d` dependency

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689f0fa4148c8323b4a564be7ef5dc7b