### PR TITLE
Replace skill map with React Flow mind map

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,7 +17,9 @@ export default function HomePage() {
           <p className="max-w-3xl text-slate-500">
             Domains orbit my core problem-solving center. Each skill connects to its domain and bridges others.
           </p>
-          <SkillMap dark />
+          <div className="max-w-5xl mx-auto">
+            <SkillMap />
+          </div>
           <ul className="mt-4 grid gap-2 text-sm text-slate-500 md:grid-cols-2">
             <li>
               <b>Domains:</b> Core Problem Solving; Technical Trades; Engineering & Design; Digital & Creative; Business & Marketing

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-force-graph": "^1.48.0",
-    "react-force-graph-2d": "^1.28.0"
+    "react-force-graph-2d": "^1.28.0",
+    "reactflow": "^11.11.4"
   },
   "devDependencies": {
     "@eslint/compat": "1.2.8",


### PR DESCRIPTION
## Summary
- Replace force graph with React Flow-based mind map card
- Wrap skill map on home page to fit layout and theme
- Add React Flow dependency

## Testing
- `npm run lint`
- `npm run build` *(fails: failed to fetch font files)*

------
https://chatgpt.com/codex/tasks/task_e_689f13664b3083239774080aad74e0a6