### PR TITLE
feat: add themed skill map with csv layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,17 +15,26 @@ export default function HomePage() {
         <div className="container mx-auto px-4 space-y-4">
           <h2 className="text-2xl font-bold">Interconnected Skill Map</h2>
           <p className="max-w-3xl text-slate-500">
-            Domains orbit my core problem-solving center. Each skill connects to its domain and bridges others.
+            Categories group my capabilities; lines show crossovers where skills reinforce each other.
           </p>
           <div className="max-w-5xl mx-auto">
             <SkillMap />
           </div>
           <ul className="mt-4 grid gap-2 text-sm text-slate-500 md:grid-cols-2">
             <li>
-              <b>Domains:</b> Core Problem Solving; Technical Trades; Engineering & Design; Digital & Creative; Business & Marketing
+              <b>Core Problem Solving:</b> Learning Agility, Pattern Recognition, Adaptability, Knowledge Breadth
             </li>
             <li>
-              <b>Sample skills:</b> Learning Agility; Embedded Systems Programming; Fusion 360; SEO & Content Strategy; Web Development
+              <b>Technical Trades:</b> Masonry & Construction, Woodworking & Woodturning, Electrical Engineering Fundamentals
+            </li>
+            <li>
+              <b>Engineering & Design:</b> CAD/CAM (Fusion 360, Aspire), PCB Design (Eagle, KiCad), Embedded Systems Programming
+            </li>
+            <li>
+              <b>Digital & Creative:</b> Web Development (HTML/CSS/JS/Next.js), Adobe/DaVinci (Video & Design)
+            </li>
+            <li>
+              <b>Business & Marketing:</b> SEO & Content Strategy, Brand Building & GTM
             </li>
           </ul>
         </div>

--- a/public/skills/links.csv
+++ b/public/skills/links.csv
@@ -1,28 +1,19 @@
 source,target
-Core Problem Solving,Learning Agility
-Core Problem Solving,Pattern Recognition
-Core Problem Solving,Adaptability
-Core Problem Solving,Knowledge Breadth
-
-Technical Trades,Masonry & Construction
-Technical Trades,Woodworking & Woodturning
-Technical Trades,Electrical Engineering Fundamentals
-
-Engineering & Design,CAD/CAM (Fusion 360, Aspire)
-Engineering & Design,PCB Design (Eagle, KiCad)
-Engineering & Design,Embedded Systems Programming
-
-Digital & Creative,Web Development (HTML/CSS/JS/Next.js)
-Digital & Creative,Adobe/DaVinci (Video & Design)
-
-Business & Marketing,SEO & Content Strategy
-Business & Marketing,Brand Building & GTM
-
-# cross-domain bridges
-Technical Trades,Engineering & Design
-Engineering & Design,Digital & Creative
-Digital & Creative,Business & Marketing
-Core Problem Solving,Technical Trades
-Core Problem Solving,Engineering & Design
-Core Problem Solving,Digital & Creative
-Core Problem Solving,Business & Marketing
+Core_Problem_Solving,Learning_Agility
+Core_Problem_Solving,Pattern_Recognition
+Core_Problem_Solving,Adaptability
+Core_Problem_Solving,Knowledge_Breadth
+Technical_Trades,Masonry_Construction
+Technical_Trades,Woodworking_Woodturning
+Technical_Trades,EE_Fundamentals
+Engineering_Design,CAD_CAM_Fusion360_Aspire
+Engineering_Design,PCB_Eagle_KiCad
+Engineering_Design,Embedded_Systems_Programming
+Digital_Creative,Web_Dev_HTML_CSS_JS_Next
+Digital_Creative,Adobe_DaVinci_Video_Design
+Business_Marketing,SEO_Content_Strategy
+Business_Marketing,Brand_Building_GTM
+Technical_Trades,Engineering_Design
+Engineering_Design,Digital_Creative
+Digital_Creative,Business_Marketing
+PCB_Eagle_KiCad,SEO_Content_Strategy

--- a/public/skills/nodes.csv
+++ b/public/skills/nodes.csv
@@ -1,21 +1,20 @@
 id,label,type
-Core Problem Solving,Core Problem Solving,domain
-Technical Trades,Technical Trades,domain
-Engineering & Design,Engineering & Design,domain
-Digital & Creative,Digital & Creative,domain
-Business & Marketing,Business & Marketing,domain
-
-Learning Agility,Learning Agility,skill
-Pattern Recognition,Pattern Recognition,skill
+Core_Problem_Solving,Core Problem Solving,domain
+Technical_Trades,Technical Trades,domain
+Engineering_Design,Engineering & Design,domain
+Digital_Creative,Digital & Creative,domain
+Business_Marketing,Business & Marketing,domain
+Learning_Agility,Learning Agility,skill
+Pattern_Recognition,Pattern Recognition,skill
 Adaptability,Adaptability,skill
-Knowledge Breadth,Knowledge Breadth,skill
-Masonry & Construction,Masonry & Construction,skill
-Woodworking & Woodturning,Woodworking & Woodturning,skill
-Electrical Engineering Fundamentals,Electrical Engineering Fundamentals,skill
-CAD/CAM (Fusion 360, Aspire),CAD/CAM (Fusion 360, Aspire),skill
-PCB Design (Eagle, KiCad),PCB Design (Eagle, KiCad),skill
-Embedded Systems Programming,Embedded Systems Programming,skill
-Web Development (HTML/CSS/JS/Next.js),Web Development (HTML/CSS/JS/Next.js),skill
-Adobe/DaVinci (Video & Design),Adobe/DaVinci (Video & Design),skill
-SEO & Content Strategy,SEO & Content Strategy,skill
-Brand Building & GTM,Brand Building & GTM,skill
+Knowledge_Breadth,Knowledge Breadth,skill
+Masonry_Construction,Masonry & Construction,skill
+Woodworking_Woodturning,Woodworking & Woodturning,skill
+EE_Fundamentals,Electrical Engineering Fundamentals,skill
+CAD_CAM_Fusion360_Aspire,CAD/CAM (Fusion 360, Aspire),skill
+PCB_Eagle_KiCad,PCB Design (Eagle, KiCad),skill
+Embedded_Systems_Programming,Embedded Systems Programming,skill
+Web_Dev_HTML_CSS_JS_Next,Web Development (HTML/CSS/JS/Next.js),skill
+Adobe_DaVinci_Video_Design,Adobe/DaVinci (Video & Design),skill
+SEO_Content_Strategy,SEO & Content Strategy,skill
+Brand_Building_GTM,Brand Building & GTM,skill


### PR DESCRIPTION
## Summary
- overhaul SkillMap with Supabase-style theming, deterministic CSV layout, and animated crossover edges
- update home page section and fallback list
- replace skills CSVs with machine-safe IDs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689f1910081c8323bed42094506c6584