### PR TITLE
fix gradient text runtime error

### DIFF
--- a/components/textAnimations/gradient-text.tsx
+++ b/components/textAnimations/gradient-text.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import { motion, type Transition } from "framer-motion";
 


### PR DESCRIPTION
## Summary
- mark gradient text component as a client component so framer-motion animations render correctly

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font file from `https://fonts.gstatic.com/...`)*

------
https://chatgpt.com/codex/tasks/task_e_68a008cf69c883239178b8b21c1e4ad3